### PR TITLE
`--modified-since` option to only run target for packages with changes

### DIFF
--- a/mazel/commands/clean.py
+++ b/mazel/commands/clean.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from mazel.label import Target
 
 # Import module for easier patching during test
@@ -8,11 +10,17 @@ from . import label_common
 #   `mazel run :clean`
 # TODO should we allow a label-based target instead of always using "clean"?
 @label_common.label_command
-def clean(label: str, with_ancestors: bool, with_descendants: bool) -> None:
+def clean(
+    label: str,
+    with_ancestors: bool,
+    with_descendants: bool,
+    modified_since: Optional[str] = None,
+) -> None:
     label_common.LabelRunner(
         handler=label_common.MakeLabel(),
         default_target=Target("clean"),
         run_order=label_common.RunOrder.REVERSED,
         with_ancestors=with_ancestors,
         with_descendants=with_descendants,
+        modified_since=modified_since,
     ).run(label)

--- a/mazel/commands/echo.py
+++ b/mazel/commands/echo.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from mazel.label import Target
@@ -16,7 +18,12 @@ class EchoHandler(label_common.TargetHandler):
 
 
 @label_common.label_command
-def echo(label: str, with_ancestors: bool, with_descendants: bool) -> None:
+def echo(
+    label: str,
+    with_ancestors: bool,
+    with_descendants: bool,
+    modified_since: Optional[str] = None,
+) -> None:
     """For debugging what packages would get run by run/test, echo the package:target"""
     handler_cls = EchoHandler
 
@@ -26,4 +33,5 @@ def echo(label: str, with_ancestors: bool, with_descendants: bool) -> None:
         run_order=label_common.RunOrder.ORDERED,
         with_ancestors=with_ancestors,
         with_descendants=with_descendants,
+        modified_since=modified_since,
     ).run(label)

--- a/mazel/commands/format.py
+++ b/mazel/commands/format.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from mazel.label import Target
 
 # Import module for easier patching during test
@@ -8,10 +10,16 @@ from . import label_common
 #   `mazel run :format`
 # TODO should we allow a label-based target instead of always using "format"?
 @label_common.label_command
-def format(label: str, with_ancestors: bool, with_descendants: bool) -> None:
+def format(
+    label: str,
+    with_ancestors: bool,
+    with_descendants: bool,
+    modified_since: Optional[str] = None,
+) -> None:
     label_common.LabelRunner(
         handler=label_common.MakeLabel(),
         default_target=Target("format"),
         with_ancestors=with_ancestors,
         with_descendants=with_descendants,
+        modified_since=modified_since,
     ).run(label)

--- a/mazel/commands/run.py
+++ b/mazel/commands/run.py
@@ -1,9 +1,16 @@
+from typing import Optional
+
 # Import module for easier patching during test
 from . import label_common
 
 
 @label_common.label_command
-def run(label: str, with_ancestors: bool, with_descendants: bool) -> None:
+def run(
+    label: str,
+    with_ancestors: bool,
+    with_descendants: bool,
+    modified_since: Optional[str] = None,
+) -> None:
     """Runs a specific Makefile target.
 
     The equivalent of `cd mypackage; make shell`:
@@ -19,4 +26,5 @@ def run(label: str, with_ancestors: bool, with_descendants: bool) -> None:
         run_order=label_common.RunOrder.ORDERED,
         with_ancestors=with_ancestors,
         with_descendants=with_descendants,
+        modified_since=modified_since,
     ).run(label)

--- a/mazel/commands/test.py
+++ b/mazel/commands/test.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from mazel.label import Target
@@ -16,7 +18,11 @@ from . import label_common
     help="Only show stdout/stderr after error, or stream everything.",
 )
 def test(
-    label: str, test_output: str, with_ancestors: bool, with_descendants: bool
+    label: str,
+    test_output: str,
+    with_ancestors: bool,
+    with_descendants: bool,
+    modified_since: Optional[str] = None,
 ) -> None:
     handler_cls = (
         label_common.MakeLabelCaptureErrors
@@ -30,4 +36,5 @@ def test(
         run_order=label_common.RunOrder.ORDERED,
         with_ancestors=with_ancestors,
         with_descendants=with_descendants,
+        modified_since=modified_since,
     ).run(label)

--- a/mazel/git.py
+++ b/mazel/git.py
@@ -1,0 +1,21 @@
+import subprocess
+from pathlib import Path
+
+from .fs import cd
+from .types import CommitRange
+
+
+def git_modified_files(repo_dir: Path, commit_range: CommitRange) -> list[Path]:
+
+    with cd(repo_dir):  # Can technically run anywhere *within* the repo
+        # Could use GitPython instead, but we only need to run one command and parse
+        # output.
+        # If we get more advanced, consider switching over to a proper library.
+        cmd = subprocess.run(
+            ["git", "diff", "--name-only", commit_range.r1, commit_range.r2],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    return [Path(fn) for fn in cmd.stdout.strip().split("\n")]

--- a/mazel/types.py
+++ b/mazel/types.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import NewType
+
+# Represents a git commit/pointer
+Commit = NewType("Commit", str)
+
+
+@dataclass
+class CommitRange:
+    """
+    r1..r2 (r2 defaults to HEAD)
+    https://git-scm.com/docs/git-rev-parse#_dotted_range_notations
+    https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
+    """
+
+    r1: Commit  # "from" commit
+    r2: Commit = Commit("HEAD")  # "to" commit
+
+    @classmethod
+    def parse(cls, value: str) -> "CommitRange":
+        parts = value.split("..")
+        if len(parts) == 2:
+            r1, r2 = parts
+            return CommitRange(r1=Commit(r1), r2=Commit(r2))
+
+        return CommitRange(r1=Commit(parts[0]))

--- a/tests/test_commands/test_clean.py
+++ b/tests/test_commands/test_clean.py
@@ -18,6 +18,7 @@ class CleanCommandTest(LabelCommandTestCase):
             run_order=RunOrder.REVERSED,
             with_ancestors=False,
             with_descendants=False,
+            modified_since=None,
         )
 
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_commands/test_echo.py
+++ b/tests/test_commands/test_echo.py
@@ -18,6 +18,7 @@ class EchoCommandTest(LabelCommandTestCase):
             run_order=RunOrder.ORDERED,
             with_ancestors=False,
             with_descendants=False,
+            modified_since=None,
         )
 
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_commands/test_format.py
+++ b/tests/test_commands/test_format.py
@@ -16,6 +16,7 @@ class FormatCommandTest(LabelCommandTestCase):
             Target("format"),
             with_ancestors=False,
             with_descendants=False,
+            modified_since=None,
         )
 
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_commands/test_run.py
+++ b/tests/test_commands/test_run.py
@@ -17,6 +17,7 @@ class RunCommandTest(LabelCommandTestCase):
             run_order=RunOrder.ORDERED,
             with_ancestors=False,
             with_descendants=False,
+            modified_since=None,
         )
         self.assertIsInstance(
             self.mock_runner.call_args_list[0][1]["handler"], MakeLabelPassInterrupt

--- a/tests/test_commands/test_test.py
+++ b/tests/test_commands/test_test.py
@@ -19,6 +19,7 @@ class TestCommandTest(LabelCommandTestCase):
             run_order=RunOrder.ORDERED,
             with_ancestors=False,
             with_descendants=False,
+            modified_since=None,
         )
         self.assertIsInstance(
             self.mock_runner.call_args_list[0][1]["handler"], MakeLabel
@@ -38,6 +39,7 @@ class TestCommandTest(LabelCommandTestCase):
             run_order=RunOrder.ORDERED,
             with_ancestors=False,
             with_descendants=False,
+            modified_since=None,
         )
 
         self.assertEqual(result.exit_code, 1)
@@ -52,6 +54,7 @@ class TestCommandTest(LabelCommandTestCase):
             run_order=RunOrder.ORDERED,
             with_ancestors=False,
             with_descendants=False,
+            modified_since=None,
         )
         self.assertIsInstance(
             self.mock_runner.call_args_list[0][1]["handler"], MakeLabelCaptureErrors

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase, mock
+
+from mazel.git import git_modified_files
+from mazel.types import CommitRange
+
+
+class GitModifiedFilesTest(TestCase):
+    def run(self, result=None):
+        with mock.patch(
+            "mazel.git.subprocess.run", autospec=True
+        ) as self.mock_run, mock.patch(
+            "mazel.git.cd", autospec=True
+        ) as self.mock_cd, TemporaryDirectory() as temp_dir:
+
+            self.mock_run.return_value.stdout = (
+                "package_a/file.py\npackage_b/other.py\n"
+            )
+            self.temp_dir = Path(temp_dir)
+            super().run(result=result)
+
+    def test(self):
+        modified = git_modified_files(
+            self.temp_dir, CommitRange.parse("7504f56..ba920f9")
+        )
+
+        self.assertEqual(
+            modified, [Path("package_a/file.py"), Path("package_b/other.py")]
+        )
+
+        self.mock_run.assert_called_once_with(
+            ["git", "diff", "--name-only", "7504f56", "ba920f9"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        # Ensure git executed in expected directory
+        self.mock_cd.assert_called_once_with(self.temp_dir)
+
+    def test_default_to_head(self):
+        git_modified_files(self.temp_dir, CommitRange.parse("7504f56"))
+
+        self.mock_run.assert_called_once_with(
+            ["git", "diff", "--name-only", "7504f56", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+
+from mazel.types import Commit, CommitRange
+
+
+class CommitRangeTest(TestCase):
+    def test_parse_pair(self):
+        rev = CommitRange.parse("39fc076..92c469d")
+
+        self.assertEqual(rev, CommitRange(Commit("39fc076"), Commit("92c469d")))
+
+    def test_parse_single(self):
+        rev = CommitRange.parse("39fc076")
+
+        self.assertEqual(rev, CommitRange(Commit("39fc076"), Commit("HEAD")))


### PR DESCRIPTION
Uses `git` command on $PATH to run a `git diff --name-only` to find the changes that have been modified since a specific change, or between a range of commits.

Sample usage:
```
mazel test --modified-since=b8cfc92 //
```

Consider combining `--with-descendants` to get all modified any downstream impacted packages.