### PR TITLE
Avoid getting siblings/cousins of the start node when using both descendants and ancestors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.0.4 - 2022-11-10
+------------------
+
+- Avoid including "sibling" or "cousin" packages of the start node when using both ``--with-descendants`` and ``--with-ancestors``.  Only descendants of the start node and direct ancestors of the start node are including, not descendants of any parent / grandparent node.
+
+
 0.0.3 - 2022-10-16
 ------------------
 

--- a/mazel/commands/label_common.py
+++ b/mazel/commands/label_common.py
@@ -73,7 +73,7 @@ def expand_ancestry(
 ) -> List[Package]:
     packages: List[Package] = []
 
-    def recurse(node: Node) -> None:
+    def recurse(node: Node, walking_ancestors: bool = False) -> None:
         # This node has already been processed, don't need to readd it or
         # its parents/chilren
         if node.package in packages:
@@ -84,10 +84,13 @@ def expand_ancestry(
         if with_ancestors:
             # Add parents and recursive to grandparents until exhausted
             for parent in node.parents:
-                recurse(parent)
+                recurse(parent, walking_ancestors=True)
 
-        if with_descendants:
-            # Add children and recursive to grandchildren until exhausted
+        if with_descendants and not walking_ancestors:
+            # Add children and recursive to grandchildren until exhausted,
+            # but do not recurse to nodes that are not direct descendants of the
+            # start node (e.g. siblings or "cousins" of the start node)
+            # related, but n
             for child in node.children:
                 recurse(child)
 


### PR DESCRIPTION
```
A -> B -> C
   \
    -> D -> E
```

At present, `mazel run --with-descendants --with-ancestors //B:target` would get it's descendant, `C`, and it's ancestor `A`, but when getting the ancestor will also process the descendants of `A`, such that `D` and `E` will get run too.

This change ensures only direct linear ancestors get included and no "siblings" or "cousins" of `B` are used: so only `A`, `B`, & `C` are run.